### PR TITLE
fix: merge document settings with defaults

### DIFF
--- a/src/FountainLanguageServer.ts
+++ b/src/FountainLanguageServer.ts
@@ -205,7 +205,10 @@ export class FountainLanguageServer {
             });
             this.documentSettings.set(resource, result);
         }
-        return result.then(it => it || FountainLanguageServer.GLOBAL_SETTINGS);
+        return result.then(it => ({
+            ...FountainLanguageServer.GLOBAL_SETTINGS,
+            ...(it || {})
+        }));
     }
     
     private async validateTextDocument(textDocument: TextDocument): Promise<void> {
@@ -254,4 +257,3 @@ function naiveNumPages(parsedScript: FountainScript) {
 
     return 1 + Math.ceil(numPageLines / pageHeight);// assume title page is one page.
 }
-

--- a/tests/FountainLanguageServer.spec.ts
+++ b/tests/FountainLanguageServer.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { Connection, TextDocuments } from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { FountainLanguageServer } from '../src/FountainLanguageServer';
+
+describe('FountainLanguageServer settings', () => {
+    it('merges empty document settings with the defaults', async () => {
+        const connection = {
+            workspace: {
+                getConfiguration: async () => ({})
+            }
+        } as unknown as Connection;
+
+        const documents = {} as TextDocuments<TextDocument>;
+        const server = new FountainLanguageServer(connection, documents);
+
+        server.hasConfigurationCapability = true;
+
+        const settings = await server.getDocumentSettings('file:///test.fountain');
+
+        expect(settings.guessCharacterGenders).to.equal(true);
+    });
+});


### PR DESCRIPTION
## Summary

Merge document-scoped settings with the server defaults instead of treating the retrieved settings object as a complete replacement.

## Problem

When the client supports `workspace/configuration`, the language server requests the `fountain` configuration section.

In VS Code, this may return an empty object when no Fountain settings are declared:

```ts
{}
```

The previous implementation only fell back to the global settings when the returned value was falsy:

```ts
return result.then(it => it || FountainLanguageServer.GLOBAL_SETTINGS);
```

Because an empty object is truthy, the default value of `guessCharacterGenders` was not applied. As a result, `settings.guessCharacterGenders` was `undefined`, which disabled character-stat enrichment, including metadata explicitly provided through `.fountainrc`.

## Reproduction

This was reproduced through the `Fountain Scriptwriting` VS Code extension, which uses this language server.

With a valid project-local `.fountainrc`, character metadata such as `gender` was ignored and the character statistics panel remained unenriched. Inspecting the server showed that an empty `fountain` configuration object would cause the default `guessCharacterGenders: true` value to be lost.

After applying this change to the locally installed server bundle, `.fountainrc` metadata was loaded and displayed correctly.

## Fix

Merge the retrieved document settings over the global defaults:

```ts
return result.then(it => ({
    ...FountainLanguageServer.GLOBAL_SETTINGS,
    ...(it || {})
}));
```

This preserves explicitly configured document settings while ensuring omitted settings retain their default values.

## Testing

Added a regression test covering an empty document configuration object.

Verified locally with:

* `npm test` ⇾ 115 tests passing
* `npm run lint`
* `npm run build`

## AI assistance

I used ChatGPT to help investigate the installed extension bundle, identify the settings fallback issue, and review the patch. I manually applied, reviewed, and tested the changes locally.